### PR TITLE
Fix: cast number to array

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,8 +5,7 @@
   "rules": {
     "no-eval": 2,
     "no-console": 2,
-    "strict": 2,
-    "no-extra-strict": 2,
+    "strict": [2, "global"],
     "guard-for-in": 2,
     "wrap-iife": 2,
     "new-cap": 2,

--- a/lib/castValue.js
+++ b/lib/castValue.js
@@ -22,7 +22,7 @@ module.exports = function castValue(value, type) {
             return value;
         }
 
-        return value.split(',');
+        return value.toString().split(',');
     }
 
     throw new Error('Unsupported config value type: ' + type.name);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,36 +1,5 @@
 {
   "env": {
-    "node": true,
     "mocha": true
-  },
-  "rules": {
-    "no-eval": 2,
-    "no-console": 2,
-    "strict": 2,
-    "no-extra-strict": 2,
-    "guard-for-in": 2,
-    "wrap-iife": 2,
-    "new-cap": 2,
-    "no-caller": 2,
-    "curly": 2,
-    "eqeqeq": 2,
-    "no-bitwise": 2,
-    "no-empty": 2,
-    "no-use-before-define": 2,
-    "no-new": 2,
-    "max-depth": [2, 3],
-    "no-undef": 2,
-    "no-unused-vars": 2,
-    "max-params": [2, 4],
-    "max-statements": [2, 20],
-    "complexity": [2, 10],
-    "quotes": [2, "single"],
-    "no-mixed-requires": 0,
-    "consistent-return": 0,
-    "no-underscore-dangle": 0,
-
-    "max-len": [2, 140],
-    "no-trailing-spaces": 2,
-    "eol-last": 2
   }
 }

--- a/test/lib/castValue.test.js
+++ b/test/lib/castValue.test.js
@@ -122,5 +122,13 @@ describe('castValue', function() {
             assert.strictEqual(returnedValue[1], 'bar');
             assert.strictEqual(returnedValue[2], 'baz');
         });
+
+        it('casts a number to a string before returning it wrapped in an array', function() {
+            var returnedValue = castValue(123, Array);
+
+            assert.strictEqual(Array.isArray(returnedValue), true);
+            assert.strictEqual(returnedValue.length, 1);
+            assert.strictEqual(returnedValue.args[0], '123');
+        });
     });
 });


### PR DESCRIPTION
When passing a single numeric argument to be cast to an array by konfiga, an error could be thrown. This PR addresses this issue. This PR also updates the ESLint files to not mistakenly show errors.

@chrisnewtn Ready for review.