### PR TITLE
Custom parsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,28 @@ var config = konfiga(schema, { argv: myOwnParsedArgs });
 #### `env`
 By default, Konfiga get values from the enviroment using the `process.env` global. I'm not sure why you'd ever need to pass in your own equivilant object, but since I added the option for command line args, I felt I should add one for this too.
 
+#### `parsers`
+Konfiga comes with default parsers. To add more parsers, or override existing parsers, this array can be used. For example, to add a Set type:
+
+```js
+var config = konfiga(schema, {
+    parsers: [
+        {
+            Type: Set,
+            parser: function(value) {
+                if (!value) {
+                    return new Set();
+                }
+
+                if (Array.isArray(value)) {
+                    return new Set(value);
+                }
+
+                return new Set(value.toString().split(','));
+            }
+        }
+    ]
+});
+```
+
 [1]: https://github.com/substack/minimist

--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@
 
 var minimist = require('minimist');
 var processConfig = require('./lib/processConfig');
+var defaultParsers = require('./lib/defaultParsers');
 
 module.exports = function konfiga(schema, options) {
     var opts = options || {};
     var argv = opts.argv || minimist(process.argv.slice(2));
     var env = opts.env || process.env;
+    var parsers = new Map(defaultParsers);
 
-    return processConfig(schema, argv, env);
+    (opts.parsers || []).forEach(function(parserSpec) {
+        parsers.set(parserSpec.type, parserSpec.parser);
+    });
+
+    return processConfig(schema, argv, env, parsers);
 };

--- a/lib/castValue.js
+++ b/lib/castValue.js
@@ -1,29 +1,11 @@
 'use strict';
 
-module.exports = function castValue(value, type) {
-    if (!type || type === String) {
-        return value.toString();
+module.exports = function castValue(value, type, parsers) {
+    var parser = type ? parsers.get(type) : parsers.get('default');
+
+    if (!parser) {
+        throw new Error('Unsupported config value type: ' + type.name);
     }
 
-    if (type === Boolean) {
-        return value === 'true' || value === true;
-    }
-
-    if (type === Number) {
-        return Number(value);
-    }
-
-    if (type === Array) {
-        if (!value) {
-            return [];
-        }
-
-        if (Array.isArray(value)) {
-            return value;
-        }
-
-        return value.toString().split(',');
-    }
-
-    throw new Error('Unsupported config value type: ' + type.name);
+    return parser(value);
 };

--- a/lib/defaultParsers.js
+++ b/lib/defaultParsers.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var defaultParsers = new Map();
+
+defaultParsers.set('default', function parseDefault(value) {
+    return value.toString();
+});
+
+defaultParsers.set(String, function parseString(value) {
+    return value.toString();
+});
+
+defaultParsers.set(Boolean, function parseBoolean(value) {
+    return value === 'true' || value === true;
+});
+
+defaultParsers.set(Number, function parseNumber(value) {
+    return Number(value);
+});
+
+defaultParsers.set(Array, function parseArray(value) {
+    if (!value) {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        return value;
+    }
+
+    return value.toString().split(',');
+});
+
+module.exports = defaultParsers;
+

--- a/lib/processConfig.js
+++ b/lib/processConfig.js
@@ -2,7 +2,7 @@
 
 var castValue = require('./castValue');
 
-module.exports = function processConfig(schema, argv, env) {
+module.exports = function processConfig(schema, argv, env, parsers) {
     var config = {};
 
     Object.keys(schema).forEach(function processOption(optionName) {
@@ -12,7 +12,7 @@ module.exports = function processConfig(schema, argv, env) {
             env[optionProperties.envVariableName] ||
             optionProperties.defaultValue;
 
-        config[optionName] = castValue(value, type);
+        config[optionName] = castValue(value, type, parsers);
     });
 
     return Object.freeze(config);

--- a/test/lib/castValue.test.js
+++ b/test/lib/castValue.test.js
@@ -2,22 +2,34 @@
 
 var assert = require('assert');
 var sinon = require('sinon');
-var castValue = require('../../lib/castValue');
+var SandboxedModule = require('sandboxed-module');
+var castValue = require('../../lib/castValue'); 
 
 describe('castValue', function() {
+    var parsers;
+
+    function TestConstructor() {}
+
+    beforeEach(function() {
+        parsers = new Map([
+            ['test-type', sinon.stub().returns('returned-by-parser-two')],
+            ['default', sinon.stub().returns('returned-by-default-parser')]
+        ]);
+    });
+
     it('is a function', function() {
         assert.strictEqual(typeof castValue, 'function');
     });
 
-    it('has an arity of 2', function() {
-        assert.strictEqual(castValue.length, 2);
+    it('has an arity of 3', function() {
+        assert.strictEqual(castValue.length, 3);
     });
 
     it('throws if the type passed is not supported', function() {
         function UnsupportedType() {}
 
         function test() {
-            castValue(null, UnsupportedType);
+            castValue(null, UnsupportedType, parsers);
         }
 
         assert.throws(test, 'Unsupported config value type: UnsupportedType');
@@ -25,110 +37,35 @@ describe('castValue', function() {
 
     describe('when passed a value with no type', function() {
         var value;
+        var parsed;
 
         beforeEach(function() {
             value = {toString: sinon.stub().returns('gunk')};
+            parsed = castValue(value, undefined, parsers);
         });
 
-        it('calls the value\'s toString method', function() {
-            castValue(value);
-
-            assert.strictEqual(value.toString.callCount, 1);
+        it('calls the default parser with the value', function() {
+            assert.deepStrictEqual(parsers.get('default').args, [[value]]);
         });
 
-        it('returns the result of the value\'s toString method', function() {
-            assert.strictEqual(castValue(value), 'gunk');
+        it('returns the result of default parser', function() {
+            assert.strictEqual(parsed, 'returned-by-default-parser');
         });
     });
 
-    describe('when passed a value with a type of String', function() {
-        var value;
+    describe('when passed a valid type', function() {
+        var parsed;
 
         beforeEach(function() {
-            value = {toString: sinon.stub().returns('gunk')};
+            parsed = castValue('blah', 'test-type', parsers);
         });
 
-        it('calls the value\'s toString method', function() {
-            castValue(value, String);
-
-            assert.strictEqual(value.toString.callCount, 1);
+        it('calls the appropriate parser with the given value', function() {
+            assert.ok(parsers.get('test-type').callCount, 1);
         });
 
-        it('returns the result of the value\'s toString method', function() {
-            assert.strictEqual(castValue(value, String), 'gunk');
-        });
-    });
-
-    describe('when passed a value with and a type of Boolean', function() {
-        it('returns true if the value is "true"', function() {
-            assert.strictEqual(castValue('true', Boolean), true);
-        });
-
-        it('returns true if the value is true', function() {
-            assert.strictEqual(castValue(true, Boolean), true);
-        });
-
-        it('returns false if the value is falsey', function() {
-            assert.strictEqual(castValue(undefined, Boolean), false);
-        });
-    });
-
-    describe('when passed a value with and a type of Number', function() {
-        var numberStub;
-
-        before(function(){
-            numberStub = sinon.stub(global, 'Number').returns('numberGunk');
-        });
-
-        after(function(){
-            numberStub.restore();
-        });
-
-        it('passes the value to Number', function() {
-            castValue('42', Number);
-
-            assert.strictEqual(numberStub.calledWith('42'), true);
-
-            assert.strictEqual(numberStub.callCount, 1);
-        });
-
-        it('returns the result from Number', function() {
-            assert.strictEqual(castValue('42', Number), 'numberGunk');
-        });
-    });
-
-    describe('when passed a value with and a type of Array', function() {
-        it('returns an empty array if the value is falsey', function() {
-            var returnedValue = castValue(undefined, Array);
-
-            assert.strictEqual(Array.isArray(returnedValue), true);
-
-            assert.strictEqual(returnedValue.length, 0);
-        });
-
-        it('returns the passed value if it is already an array', function() {
-            var passedValue = [1, 2, 3];
-            var returnedValue = castValue(passedValue, Array);
-
-            assert.strictEqual(returnedValue, passedValue);
-        });
-
-        it('returns the passed comma delimited string as an array', function() {
-            var returnedValue = castValue('foo,bar,baz', Array);
-
-            assert.strictEqual(Array.isArray(returnedValue), true);
-
-            assert.strictEqual(returnedValue[0], 'foo');
-            assert.strictEqual(returnedValue[1], 'bar');
-            assert.strictEqual(returnedValue[2], 'baz');
-        });
-
-        it('casts a number to a string before returning it wrapped in an array', function() {
-            var returnedValue = castValue(123, Array);
-
-            assert.strictEqual(Array.isArray(returnedValue), true);
-            assert.strictEqual(returnedValue.length, 1);
-            assert.strictEqual(returnedValue.args[0], '123');
+        it('returns the retured value of the parser', function() {
+            assert.equal(parsed, 'returned-by-parser-two');
         });
     });
 });

--- a/test/lib/defaultParsers.test.js
+++ b/test/lib/defaultParsers.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var assert = require('assert');
+var defaultParsers = require('../../lib/defaultParsers');
+
+describe('defaultParsers', function() {
+    describe('default', function() {
+        it('calls toString on the given value, and returns the result', function() {
+            var value = {
+                toString: function() {
+                    return 'to-string-result';
+                }
+            }
+
+            assert.equal(defaultParsers.get('default')(value), 'to-string-result');
+        });
+    });
+    
+    describe('String', function() {
+        it('calls toString on the given value, and returns the result', function() {
+            var value = {
+                toString: function() {
+                    return 'to-string-result';
+                }
+            }
+
+            assert.equal(defaultParsers.get('default')(value), 'to-string-result');
+        });
+    });
+
+    describe('Boolean', function() {
+        it('returns true if the value is "true"', function() {
+            assert.strictEqual(defaultParsers.get(Boolean)('true'), true);
+        });
+
+        it('returns true if the value is true', function() {
+            assert.strictEqual(defaultParsers.get(Boolean)(true), true);
+        });
+
+        it('returns false if the value is falsey', function() {
+            assert.strictEqual(defaultParsers.get(Boolean)(undefined), false);
+        });
+    });
+
+    describe('Number', function() {
+        var numberStub;
+
+        it('returns a number', function() {
+            assert.strictEqual(defaultParsers.get(Number)(12.34), 12.34);
+        });
+
+        it('destringifies an integer', function() {
+            assert.strictEqual(defaultParsers.get(Number)('12'), 12);
+        });
+
+        it('destringifies a decimal', function() {
+            assert.strictEqual(defaultParsers.get(Number)('12.34'), 12.34);
+        });
+
+        it('destringifies other things to NaN', function() {
+            assert.ok(Number.isNaN(defaultParsers.get(Number)('blah')));
+        });
+    });
+
+    describe('Array', function() {
+        it('returns an empty array if the value is falsey', function() {
+            var returnedValue = defaultParsers.get(Array)(undefined);
+
+            assert.strictEqual(Array.isArray(returnedValue), true);
+            assert.strictEqual(returnedValue.length, 0);
+        });
+
+        it('returns the passed value if it is already an array', function() {
+            var passedValue = [1, 2, 3];
+            var returnedValue = defaultParsers.get(Array)(passedValue);
+
+            assert.strictEqual(returnedValue, passedValue);
+        });
+
+        it('returns the passed comma delimited string as an array', function() {
+            var returnedValue = defaultParsers.get(Array)('foo,bar,baz');
+
+            assert.strictEqual(Array.isArray(returnedValue), true);
+
+            assert.strictEqual(returnedValue[0], 'foo');
+            assert.strictEqual(returnedValue[1], 'bar');
+            assert.strictEqual(returnedValue[2], 'baz');
+        });
+
+        it('casts a number to a string before returning it wrapped in an array', function() {
+            var returnedValue = defaultParsers.get(Array)(123);
+
+            assert.strictEqual(Array.isArray(returnedValue), true);
+            assert.strictEqual(returnedValue.length, 1);
+            assert.strictEqual(returnedValue[0], '123');
+        });
+    });
+});

--- a/test/lib/processConfig.test.js
+++ b/test/lib/processConfig.test.js
@@ -42,12 +42,12 @@ describe('processConfig', function() {
         assert.strictEqual(typeof processConfig, 'function');
     });
 
-    it('has an arity of 3', function() {
-        assert.strictEqual(processConfig.length, 3);
+    it('has an arity of 4', function() {
+        assert.strictEqual(processConfig.length, 4);
     });
 
     it('returns a frozen object', function() {
-        var returnedObject = processConfig(exampleSchema, {}, {});
+        var returnedObject = processConfig(exampleSchema, {}, {}, 'the-parsers');
 
         assert.strictEqual(Object.isFrozen(returnedObject), true);
     });
@@ -66,7 +66,7 @@ describe('processConfig', function() {
         });
 
         it('is present on the returned object', function() {
-            var returnedObject = processConfig(exampleSchema, {}, {});
+            var returnedObject = processConfig(exampleSchema, {}, {}, 'the-parsers');
 
             assert(returnedObject.hasOwnProperty('testOption'));
             assert(returnedObject.hasOwnProperty('anotherTestOption'));
@@ -76,14 +76,14 @@ describe('processConfig', function() {
             var returnedObject;
 
             beforeEach(function(){
-                returnedObject = processConfig(exampleSchema, argv, {});
+                returnedObject = processConfig(exampleSchema, argv, {}, 'the-parsers');
             });
 
             it('is cast to the type specified in the schema', function() {
                 assert.strictEqual(castValueStub.callCount, 2);
 
-                assert(castValueStub.calledWith('testCliValue', String));
-                assert(castValueStub.calledWith('52', Number));
+                assert(castValueStub.calledWith('testCliValue', String, 'the-parsers'));
+                assert(castValueStub.calledWith('52', Number, 'the-parsers'));
             });
 
             it('has its cast value set on the return object', function() {
@@ -108,14 +108,14 @@ describe('processConfig', function() {
 
             describe('if no equivilant command line value is found', function() {
                 beforeEach(function() {
-                    returnedObject = processConfig(exampleSchema, {}, env);
+                    returnedObject = processConfig(exampleSchema, {}, env, 'the-parsers');
                 });
 
                 it('is cast to the type specified in the schema', function() {
                     assert.strictEqual(castValueStub.callCount, 2);
 
-                    assert(castValueStub.calledWith('testEnvValue', String));
-                    assert(castValueStub.calledWith('48', Number));
+                    assert(castValueStub.calledWith('testEnvValue', String, 'the-parsers'));
+                    assert(castValueStub.calledWith('48', Number, 'the-parsers'));
                 });
 
                 it('has its cast value set on the return object', function() {
@@ -126,14 +126,14 @@ describe('processConfig', function() {
 
             describe('if command line values are found also', function() {
                 beforeEach(function() {
-                    returnedObject = processConfig(exampleSchema, argv, env);
+                    returnedObject = processConfig(exampleSchema, argv, env, 'the-parsers');
                 });
 
                 it('casts and appends the command line values instead', function() {
                     assert.strictEqual(castValueStub.callCount, 2);
 
-                    assert(castValueStub.calledWith('testCliValue', String));
-                    assert(castValueStub.calledWith('52', Number));
+                    assert(castValueStub.calledWith('testCliValue', String, 'the-parsers'));
+                    assert(castValueStub.calledWith('52', Number, 'the-parsers'));
 
                     assert.strictEqual(returnedObject.testOption, 'fakeCastCliString');
                     assert.strictEqual(returnedObject.anotherTestOption, 'fakeCastCliNumber');
@@ -148,14 +148,14 @@ describe('processConfig', function() {
                 castValueStub.withArgs('defaultValue', String).returns('fakeCastDefaultString');
                 castValueStub.withArgs(42, Number).returns('fakeCastDefaultNumber');
 
-                returnedObject = processConfig(exampleSchema, {}, {});
+                returnedObject = processConfig(exampleSchema, {}, {}, 'the-parsers');
             });
 
             it('casts each default value onto the return object', function() {
                 assert.strictEqual(castValueStub.callCount, 2);
 
-                assert(castValueStub.calledWith('defaultValue', String));
-                assert(castValueStub.calledWith(42, Number));
+                assert(castValueStub.calledWith('defaultValue', String, 'the-parsers'));
+                assert(castValueStub.calledWith(42, Number, 'the-parsers'));
 
                 assert.strictEqual(returnedObject.testOption, 'fakeCastDefaultString');
                 assert.strictEqual(returnedObject.anotherTestOption, 'fakeCastDefaultNumber');


### PR DESCRIPTION
This PR adds the ability to augment konfiga with custom type parsing. It adds a `parsers` field to options. When it's not given, konfiga behaves the same as before. When given an array of `{type, parser}` objects, these add to or override the default parsers.

Ready for review!