### PR TITLE
feat: Better parse errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,7 @@
     "max-depth": [2, 3],
     "no-undef": 2,
     "no-unused-vars": 2,
-    "max-params": [2, 4],
+    "max-params": [2, 5],
     "max-statements": [2, 20],
     "complexity": [2, 10],
     "quotes": [2, "single"],

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [4.x, 6.x, 8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-branches:
-  only:
-    - master
-node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "9"

--- a/lib/castValue.js
+++ b/lib/castValue.js
@@ -1,11 +1,24 @@
 'use strict';
 
-module.exports = function castValue(value, type, parsers) {
+module.exports = function castValue(value, type, parsers, optionName, source) {
   var parser = type ? parsers.get(type) : parsers.get('default');
 
   if (!parser) {
     throw new Error('Unsupported config value type: ' + type.name);
   }
 
-  return parser(value);
+  try {
+    return parser(value);
+  } catch (err) {
+    throw new Error(
+      'Unable to parse ' +
+      value +
+      ' using ' +
+      parser.name +
+      ' for option ' +
+      optionName +
+      ' from the ' +
+      source
+    );
+  }
 };

--- a/lib/processConfig.js
+++ b/lib/processConfig.js
@@ -18,13 +18,13 @@ module.exports = function processConfig(schema, argv, env, parsers) {
     var hasDefault = Object.hasOwnProperty.call(optionProperties, 'defaultValue');
 
     if (hasArgvName) {
-      config[optionName] = castValue(argv[cmdArgName], type, parsers);
+      config[optionName] = castValue(argv[cmdArgName], type, parsers, optionName, 'command line');
     } else if (hasEnvName) {
-      config[optionName] = castValue(env[envVarname], type, parsers);
+      config[optionName] = castValue(env[envVarname], type, parsers, optionName, 'environment');
     } else if (optionProperties.required && !hasDefault) {
       missingRequiredProperties.push(optionName);
     } else {
-      config[optionName] = castValue(optionProperties.defaultValue, type, parsers);
+      config[optionName] = castValue(optionProperties.defaultValue, type, parsers, optionName, 'default value');
     }
   });
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -32,7 +32,7 @@ describe('integration tests', () => {
       }
     };
 
-    assert.throws(() => konfiga(schema, opts), 'Missing required config for: someValue');
+    assert.throws(() => konfiga(schema, opts), /Missing required config for: someValue/);
   });
 
   it('parses required config present in the environment', () => {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,13 +1,20 @@
 'use strict';
 
+const URL = require('url').URL;
 const assert = require('assert');
 const konfiga = require('../../');
 
+function CryBaby(value) {
+  throw new Error('whaaaaaa don\'t like ' + value + '!');
+}
+
 describe('integration tests', () => {
   let opts;
+  let parsers;
 
   beforeEach(() => {
     opts = {env: {}, argv: []};
+    parsers = [{type: CryBaby, parser: value => new CryBaby(value)}]
   });
 
   it('parses the default value of a required config option', () => {
@@ -34,6 +41,83 @@ describe('integration tests', () => {
 
     assert.throws(() => konfiga(schema, opts), /Missing required config for: someValue/);
   });
+
+  it('does not throw when parsing fails so long as the parser does not throw either', () => {
+    const schema = {
+      someOption: {
+        envVariableName: 'SOME_OPTION',
+        type: Number
+      }
+    };
+
+    opts = {env: {SOME_OPTION: 'test'}, argv: {}};
+
+    assert(Number.isNaN(konfiga(schema, opts).someOption),
+      'Expeceted someOption to be NaN');
+  });
+
+  it('throws when unable to parse a value from the command line', () => {
+    const schema = {
+      someOption: {
+        cmdLineArgName: 'some-option',
+        required: true,
+        type: CryBaby
+      }
+    };
+
+    opts = {env: {}, argv: {'some-option': 'test'}, parsers};
+
+    assert.throws(() => konfiga(schema, opts),
+      /Error: whaaaaaa don't like test/);
+  });
+
+  it('throws when unable to parse a value from the environment', () => {
+    const schema = {
+      someOption: {
+        envVariableName: 'SOME_OPTION',
+        required: true,
+        type: CryBaby
+      }
+    };
+
+    opts = {env: {SOME_OPTION: 'blah'}, argv: {}, parsers};
+
+    assert.throws(() => konfiga(schema, opts),
+      /Error: whaaaaaa don't like blah/);
+  });
+
+  it('throws when unable to parse a value from the default', () => {
+    const schema = {
+      someOption: {
+        defaultValue: undefined,
+        envVariableName: 'SOME_OPTION',
+        type: String
+      }
+    };
+
+    opts = {env: {}, argv: {}};
+
+    assert.throws(() => konfiga(schema, opts),
+      /TypeError: Cannot read property 'toString' of undefined/);
+  });
+
+  if (URL) {
+    it('supports URL as a default type if running Node v6+', () => {
+      const config = konfiga({
+        someValue: {
+          envVariableName: 'SOME_VALUE',
+          required: true,
+          type: URL
+        }
+      }, {
+        env: {
+          SOME_VALUE: 'http://www.example.com/'
+        }
+      });
+
+      assert.deepStrictEqual(config, {someValue: new URL('http://www.example.com/')});
+    });
+  }
 
   it('parses required config present in the environment', () => {
     const config = konfiga({

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -14,7 +14,7 @@ describe('integration tests', () => {
 
   beforeEach(() => {
     opts = {env: {}, argv: []};
-    parsers = [{type: CryBaby, parser: value => new CryBaby(value)}]
+    parsers = [{type: CryBaby, parser: function parseCryBaby (val) { return new CryBaby(val)}}]
   });
 
   it('parses the default value of a required config option', () => {
@@ -68,7 +68,7 @@ describe('integration tests', () => {
     opts = {env: {}, argv: {'some-option': 'test'}, parsers};
 
     assert.throws(() => konfiga(schema, opts),
-      /Error: whaaaaaa don't like test/);
+      /Error: Unable to parse test using parseCryBaby for option someOption from the command line/);
   });
 
   it('throws when unable to parse a value from the environment', () => {
@@ -83,7 +83,7 @@ describe('integration tests', () => {
     opts = {env: {SOME_OPTION: 'blah'}, argv: {}, parsers};
 
     assert.throws(() => konfiga(schema, opts),
-      /Error: whaaaaaa don't like blah/);
+      /Error: Unable to parse blah using parseCryBaby for option someOption from the environment/);
   });
 
   it('throws when unable to parse a value from the default', () => {
@@ -98,7 +98,7 @@ describe('integration tests', () => {
     opts = {env: {}, argv: {}};
 
     assert.throws(() => konfiga(schema, opts),
-      /TypeError: Cannot read property 'toString' of undefined/);
+      /Error: Unable to parse undefined using parseString for option someOption from the default value/);
   });
 
   if (URL) {

--- a/test/lib/castValue.test.js
+++ b/test/lib/castValue.test.js
@@ -29,7 +29,7 @@ describe('castValue', function() {
       castValue(null, UnsupportedType, parsers);
     }
 
-    assert.throws(test, 'Unsupported config value type: UnsupportedType');
+    assert.throws(test, /Unsupported config value type: UnsupportedType/);
   });
 
   describe('when passed a value with no type', function() {

--- a/test/lib/castValue.test.js
+++ b/test/lib/castValue.test.js
@@ -18,10 +18,6 @@ describe('castValue', function() {
     assert.strictEqual(typeof castValue, 'function');
   });
 
-  it('has an arity of 3', function() {
-    assert.strictEqual(castValue.length, 3);
-  });
-
   it('throws if the type passed is not supported', function() {
     function UnsupportedType() {}
 


### PR DESCRIPTION
This PR takes an unhelpful error like:

```
TypeError: Cannot read property 'toString' of undefined
```

and replaces it with something the user can action like:

```
Error: Unable to parse undefined using parseString for option someOption from the default value
```