### PR TITLE
bump minimist package to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "sinon": "^4.1.5"
   },
   "dependencies": {
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.6"
   }
 }


### PR DESCRIPTION
I've opened this PR to update the `minimist` dependency to `1.2.6` as there are security vulnerabilities with previous versions. This has been causing security issues with various services. 
Ran the tests after bumping dependency and they all passed as below:

<img width="183" alt="Screenshot 2022-06-20 at 15 21 27" src="https://user-images.githubusercontent.com/17025797/174622701-fd170bfb-ceb4-44da-9d6c-f97324b4c22e.png">
